### PR TITLE
Improve space handling to maximise image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.0(2022-05-18)
+
+### New
+* Rearrange how images and nameboxes are sorted on a mini significantly increasing creature image size
+  * Before, the namebox size has always been substracted from max_height in any configuration. Now, it will use that space for the image to maximise the size. If a namebox is requested, it will use available space first (max_height) and if not, it'll shrink the image to fit. Now, all space is optimally used and the minis are standardized in size.
+
 ## 1.6.5(2022-05-18)
 
 ### Improvements

--- a/paperminis/__init__.py
+++ b/paperminis/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '1.6.5'
+__version__ = '1.7.0'
 VERSION = __version__  # synonym

--- a/paperminis/generate_minis.py
+++ b/paperminis/generate_minis.py
@@ -153,10 +153,7 @@ class MiniBuilder:
         elif creature.size == 'L':
             m_width = self.grid_size * 2
             # Use large papers full size
-            if self.paper_format == 'tabloid' or self.paper_format == 'a3':
-                max_height_mm = m_width * 2
-            else:
-                max_height_mm = 85 if not self.paper_format == 'letter' else 76
+            max_height_mm = m_width * 2 if not self.paper_format == 'letter' else m_width * 1.82
             n_height = 10
             font_size = 2
             font_height = 70
@@ -167,9 +164,9 @@ class MiniBuilder:
             m_width = self.grid_size * 3
             # Use large papers full size
             if self.paper_format == 'tabloid' or self.paper_format == 'a3':
-                max_height_mm = m_width * 1.5
+                max_height_mm = m_width * 1.859
             else:
-                max_height_mm = 60.5 if not self.paper_format == 'letter' else 51.5
+                max_height_mm = 72.5 if not self.paper_format == 'letter' else 63.5
             n_height = 12
             font_size = 2.5
             font_height = 80
@@ -180,9 +177,9 @@ class MiniBuilder:
             m_width = self.grid_size * 4
             # Use large papers full size
             if self.paper_format == 'tabloid' or self.paper_format == 'a3':
-                max_height_mm = m_width * 1.5
+                max_height_mm = m_width * 1.645
             else:
-                max_height_mm = 82.5 if not self.paper_format == 'letter' else 73.5
+                max_height_mm = 96.5 if not self.paper_format == 'letter' else 87.5
             n_height = 14
             font_size = 3
             font_height = 100
@@ -306,16 +303,21 @@ class MiniBuilder:
             color[mask] = 255
             m_img = color
 
+        # get Textbox height
+        namebox_height = n_img.shape[0]
+
         # find optimal size of image
         # leave 1 pixel on each side for black border
+        # Fit width
         if m_img.shape[1] > width - 2:
             f = (width - 2) / m_img.shape[1]
             m_img = cv.resize(m_img, (0, 0), fx=f, fy=f)
             white_vert = np.zeros((m_img.shape[0], 1, 3), np.uint8) + 255
             m_img = np.concatenate((white_vert, m_img, white_vert), axis=1)
 
-        if m_img.shape[0] > max_height - 2:
-            f = (max_height - 2) / m_img.shape[0]
+        # Fit height
+        if m_img.shape[0] > (max_height - 2 - namebox_height):
+            f = (max_height - 2 - namebox_height) / m_img.shape[0]
             m_img = cv.resize(m_img, (0, 0), fx=f, fy=f)
             white_horiz = np.zeros((1, m_img.shape[1], 3), np.uint8) + 255
             m_img = np.concatenate((white_horiz, m_img, white_horiz), axis=0)
@@ -329,8 +331,8 @@ class MiniBuilder:
                                     np.zeros((m_img.shape[0], right, 3), np.uint8) + 255), axis=1)
         # Handle creature positioning
         if self.fixed_height:
-            if m_img.shape[0] < min_height:
-                diff = min_height - m_img.shape[0]
+            if m_img.shape[0] < (min_height - namebox_height):
+                diff = (min_height - namebox_height) - m_img.shape[0]
                 top = np.floor_divide(diff, 2)
                 bottom = top
                 if diff % 2 == 1: bottom += 1
@@ -344,8 +346,8 @@ class MiniBuilder:
                 else:
                     return 'Position setting is invalid. Chose Walking, Hovering or Flying.'
         else:
-            if m_img.shape[0] < min_height:
-                diff = min_height - m_img.shape[0]
+            if m_img.shape[0] < (min_height - namebox_height):
+                diff = (min_height - namebox_height) - m_img.shape[0]
                 top = np.floor_divide(diff, 6)
                 bottom = np.floor_divide(diff, 3)
                 if diff % 2 == 1: bottom += 1


### PR DESCRIPTION
Before, the namebox size has always been substracted. Now, it will use
that space for the image to maximise the size. If a namebox is requested, it will use
available space first (max_height) and if not, it'll shrink the image to fit.
Now, all space is optimally used and the minis are standardized in size.